### PR TITLE
win32 platform support checks

### DIFF
--- a/glue/glue.py
+++ b/glue/glue.py
@@ -126,7 +126,6 @@ async def main():
         
         if not is_win:
             os.killpg(0, signal.SIGKILL) # kill all processes in my group
-            return
 
         os.kill(0, signal.SIGTERM)
 

--- a/glue/glue.py
+++ b/glue/glue.py
@@ -1,3 +1,4 @@
+import subprocess
 import sys
 import os
 import signal
@@ -12,6 +13,11 @@ LOG_COLOR = "\033[38;5;69m"
 MSG_COLOR = "\033[38;5;195m"
 ERROR_COLOR = "\033[38;5;1m"
 TITLE = "\033[1m"
+
+def is_win32():
+    if os.name.lower() == "nt":
+        return True
+    return False
 
 async def process_stdout(proc, name):
     try:
@@ -51,19 +57,34 @@ async def pretty_stderr(proc, name):
 
 
 async def start_component(cmd, name):
+    is_win = is_win32()
+
     print(f"{TITLE}Starting {name}{RESET}")
     name_b = name.encode("utf-8")
 
     msg_channel = ch.create_channel(100)
     component_channels[name_b] = msg_channel
 
-    proc = await asyncio.create_subprocess_shell(
-        cmd,
-        cwd=os.path.join("components", name), # Undocumented!
-        stdin=asyncio.subprocess.PIPE,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
+    proc = None
+
+    if is_win:
+        print(f"{LOG_COLOR}LOG [{name}]{RESET} => Win32 platform detected, using: CREATE_NEW_PROCESS_GROUP flag...={name}")
+        proc = await asyncio.create_subprocess_shell(
+            cmd,
+            cwd=os.path.join("components", name), # Undocumented!
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP
+        )
+    else:
+        proc = await asyncio.create_subprocess_shell(
+            cmd,
+            cwd=os.path.join("components", name), # Undocumented!
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE
+        )
 
     stdout_processor = asyncio.create_task(process_stdout(proc, name_b))
     stdin_processor = asyncio.create_task(send_stdin(proc, msg_channel, name))
@@ -78,11 +99,6 @@ async def start_component(cmd, name):
     stdout_processor.cancel()
     stdin_processor.cancel()
     stderr_logger.cancel()
-
-def is_win32():
-    if os.name.lower() == "nt":
-        return True
-    return False
 
 async def main():
     is_win = is_win32()
@@ -99,9 +115,9 @@ async def main():
             py_cmd = "python"
 
         await asyncio.gather(
-            start_component("{} run.py {}".format(py_cmd, tty), "INTR"),
-            start_component("{} run.py".format(py_cmd), "RLAY"),
-            start_component("{} run.py".format(py_cmd), "CONS"),
+            start_component(f"{py_cmd} run.py {tty}", "INTR"),
+            start_component(f"{py_cmd} run.py", "RLAY"),
+            start_component(f"{py_cmd} run.py", "CONS"),
         )
     except:
         traceback.print_exc()
@@ -110,6 +126,9 @@ async def main():
         
         if not is_win:
             os.killpg(0, signal.SIGKILL) # kill all processes in my group
+            return
+
+        os.kill(0, signal.SIGTERM)
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
The tty, as well as the way we execute python scripts here on windows is much different.

This commit adds three changes:

* A check if we are on an nt-based system
* The way we execute python scripts is not by running `python3 script.py` but rather, we run `python` as is, without specifying the version.
* Limit unix specific os calls (`os.setpgrp()` and `os.killpg(0, signal.SIGKILL)`) so that they do not execute on windows