### PR TITLE
Remove win32 workarounds

### DIFF
--- a/glue/glue.py
+++ b/glue/glue.py
@@ -1,4 +1,4 @@
-import subprocess
+import sys
 import os
 import signal
 import asyncio
@@ -12,11 +12,6 @@ LOG_COLOR = "\033[38;5;69m"
 MSG_COLOR = "\033[38;5;195m"
 ERROR_COLOR = "\033[38;5;1m"
 TITLE = "\033[1m"
-
-def is_win32():
-    if os.name.lower() == "nt":
-        return True
-    return False
 
 async def process_stdout(proc, name):
     try:
@@ -56,34 +51,19 @@ async def pretty_stderr(proc, name):
 
 
 async def start_component(cmd, name):
-    is_win = is_win32()
-
     print(f"{TITLE}Starting {name}{RESET}")
     name_b = name.encode("utf-8")
 
     msg_channel = ch.create_channel(100)
     component_channels[name_b] = msg_channel
 
-    proc = None
-
-    if is_win:
-        print(f"{LOG_COLOR}LOG [{name}]{RESET} => Win32 platform detected, using: CREATE_NEW_PROCESS_GROUP flag...={name}")
-        proc = await asyncio.create_subprocess_shell(
-            cmd,
-            cwd=os.path.join("components", name), # Undocumented!
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP
-        )
-    else:
-        proc = await asyncio.create_subprocess_shell(
-            cmd,
-            cwd=os.path.join("components", name), # Undocumented!
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE
-        )
+    proc = await asyncio.create_subprocess_shell(
+        cmd,
+        cwd=os.path.join("components", name), # Undocumented!
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
 
     stdout_processor = asyncio.create_task(process_stdout(proc, name_b))
     stdin_processor = asyncio.create_task(send_stdin(proc, msg_channel, name))
@@ -99,35 +79,31 @@ async def start_component(cmd, name):
     stdin_processor.cancel()
     stderr_logger.cancel()
 
-async def main():
-    is_win = is_win32()
-    tty = "dev/ttys005"
-    py_cmd = "python3"
+def is_win32():
+    if os.name.lower() == "nt":
+        return True
+    return False
 
-    if not is_win:
-        os.setpgrp() # create new process group, become its leader
+async def main():
+    isWin = is_win32()
+    if isWin:
+        # bail
+        print("To use esoteric editor on Windows, consider using WSL.")
+        return
+
+    os.setpgrp() # create new process group, become its leader
     
     try:
-        if is_win:
-            print("Win32 platform detected!!!")
-            tty = "/dev/cons1"
-            py_cmd = "python"
-        
         await asyncio.gather(
-            start_component(f"{py_cmd} run.py {tty}", "INTR"),
-            start_component(f"{py_cmd} run.py", "RLAY"),
-            start_component(f"{py_cmd} run.py", "CONS"),
+            start_component("python3 run.py /dev/ttys005", "INTR"),
+            start_component("python3 run.py", "RLAY"),
+            start_component("python3 run.py", "CONS"),
         )
-        
     except:
         traceback.print_exc()
     finally:
-        print(f"{LOG_COLOR}Killing components...")
-        
-        if not is_win:
-            os.killpg(0, signal.SIGKILL) # kill all processes in my group
-        
-        os.kill(os.getpid(), signal.SIGTERM)
+        print("bye")
+        os.killpg(0, signal.SIGKILL) # kill all processes in my group
 
 if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
These workarounds from re-visiting this code simply don't work, and there are lingering python processes after closing esoeditor